### PR TITLE
Fix incorrect jasper flags for cmake in evaluation/BUILD/build_jasper.sh

### DIFF
--- a/evaluation/BUILD/build_jasper.sh
+++ b/evaluation/BUILD/build_jasper.sh
@@ -62,7 +62,7 @@ else
 	export CFLAGS="-g -O0 -fsanitize=address"
 	export CXXFLAGS="-g -O0 -fsanitize=address"
 	cd $(dirname ${BIN_PATH})/jasper/SRC_MemLock/build
-	cmake -G "Unix Makefiles" -JAS_ENABLE_SHARED=off -DCMAKE_INSTALL_PREFIX=$(dirname ${BIN_PATH})/jasper/SRC_MemLock/build ..
+	cmake -G "Unix Makefiles" -DJAS_ENABLE_SHARED=off -DCMAKE_INSTALL_PREFIX=$(dirname ${BIN_PATH})/jasper/SRC_MemLock/build ..
 	make
 	make install
 
@@ -75,7 +75,7 @@ else
 	export CFLAGS="-g -O0 -fsanitize=address"
 	export CXXFLAGS="-g -O0 -fsanitize=address"
 	cd $(dirname ${BIN_PATH})/jasper/SRC_AFL/build
-	cmake -G "Unix Makefiles" -JAS_ENABLE_SHARED=off -DCMAKE_INSTALL_PREFIX=$(dirname ${BIN_PATH})/jasper/SRC_AFL/build ..
+	cmake -G "Unix Makefiles" -DJAS_ENABLE_SHARED=off -DCMAKE_INSTALL_PREFIX=$(dirname ${BIN_PATH})/jasper/SRC_AFL/build ..
 	make
 	make install
 


### PR DESCRIPTION
The CMake parameter should not be `-JAS_ENABLE_SHARED=off`, but `-DJAS_ENABLE_SHARED=off`, as pointed out by [jasper-manual](https://jasper-software.github.io/jasper-manual/releases/version-2.0.33/html/install.html):
```
The option OPTION can be set to the value VALUE with a command-line option
of the form -DOPTION=VALUE
```